### PR TITLE
Switch back to uninitialised external-name as uid

### DIFF
--- a/apis/zone/v1alpha1/types.go
+++ b/apis/zone/v1alpha1/types.go
@@ -19,9 +19,6 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/crossplane/crossplane-runtime/pkg/reference"
-	"github.com/crossplane/crossplane-runtime/pkg/resource"
-
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
@@ -278,9 +275,6 @@ type ZoneParameters struct {
 
 // ZoneObservation are the observable fields of a Zone.
 type ZoneObservation struct {
-	// ZoneID is the Cloudflare generated ID of the zone
-	ZoneID string `json:"zoneId,omitempty"`
-
 	// AccountID is the account ID that this zone exists under
 	AccountID string `json:"accountId,omitempty"`
 
@@ -380,18 +374,4 @@ type ZoneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Zone `json:"items"`
-}
-
-// ExtractZoneID provides an extraction value function
-// that can be used by other resources to refer to the
-// Zone ID when using a reference or a selector to a
-// Zone.
-func ExtractZoneID() reference.ExtractValueFn {
-	return func(mg resource.Managed) string {
-		r, ok := mg.(*Zone)
-		if !ok {
-			return ""
-		}
-		return r.Status.AtProvider.ZoneID
-	}
 }

--- a/internal/clients/zones/zone.go
+++ b/internal/clients/zones/zone.go
@@ -131,7 +131,6 @@ func NewClient(cfg clients.Config) Client {
 // GenerateObservation creates an observation of a cloudflare Zone
 func GenerateObservation(in cloudflare.Zone) v1alpha1.ZoneObservation {
 	return v1alpha1.ZoneObservation{
-		ZoneID:            in.ID,
 		AccountID:         in.Account.ID,
 		Account:           in.Account.Name,
 		DevModeTimer:      in.DevMode,

--- a/package/crds/zone.cloudflare.crossplane.io_zones.yaml
+++ b/package/crds/zone.cloudflare.crossplane.io_zones.yaml
@@ -407,9 +407,6 @@ spec:
                   verificationKey:
                     description: VerificationKey indicates the Verification key set on this Zone.
                     type: string
-                  zoneId:
-                    description: ZoneID is the Cloudflare generated ID of the zone
-                    type: string
                 type: object
               conditions:
                 description: Conditions of the resource.


### PR DESCRIPTION
It turns out that the default behaviour of crossplane to initialise the
external-name annotation of a resource can be overridden in the Setup
method of the controller. We pass an empty `Initializers{}` setting, which
stops the external-name field from being pre-set, and allows us to
assume that if the field is not the zero value (empty string), then it
is a valid ID for a Cloudflare Zone.

This allows us to remove some additional code around sanity checking the
external-name and means we can use the standard ExternalName
ExtractValueFn to pull back the Zone UID.

Signed-off-by: Ben Agricola <bagricola@squiz.co.uk>